### PR TITLE
LPS-44269

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutExporter.java
@@ -577,6 +577,8 @@ public class LayoutExporter {
 			Element layoutElement = portletDataContext.getExportDataElement(
 				layout);
 
+			layoutElement.addAttribute("priority", layout.getPriority()+"");
+
 			layoutElement.addAttribute(Constants.ACTION, Constants.SKIP);
 
 			return;


### PR DESCRIPTION
Hi Norbert,

this is an alternate fix which might be interesting. The idea is to export layout priorities, then update priorities during import based on exported data. This fix will cover both cases: creating new layouts in staging and updating prioritis w/o creating any new layout.

Please note that code is not well finished, just a Proof of Concept.

Adding @lipusz

I think this one is easier to backport as it has no special requirements (maybe some extra checks to support importing of old lars)

Does it make sense? what do you think?
