### PR TITLE
LPS-47163 Load fresh entity from cache to prevent StaleObjectStateException

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5859,6 +5859,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				!PropsValues.AUTH_PIPELINE_ENABLE_LIFERAY_CHECK ||
 				Validator.isNull(user.getDigest())) {
 
+				user = userPersistence.fetchByPrimaryKey(user.getUserId());
+
 				String digest = user.getDigest(password);
 
 				user.setDigest(digest);


### PR DESCRIPTION
Hi Norbi,

This simple fix is to avoid StageObjectStateException. Please see the similar patterns below the fix.

Cheers,
Vilmos
