### PR TITLE
[TECHNICAL-SUPPORT] LPS-54494 ArrayIndexOutOfBoundsException occurs when there are more result than "index.search.limit" after LPS-44108

### DIFF
--- a/portal-impl/src/com/liferay/portal/search/lucene/LuceneIndexSearcher.java
+++ b/portal-impl/src/com/liferay/portal/search/lucene/LuceneIndexSearcher.java
@@ -513,6 +513,10 @@ public class LuceneIndexSearcher extends BaseIndexSearcher {
 
 		int total = browseResult.getNumHits();
 
+		if (total > PropsValues.INDEX_SEARCH_LIMIT) {
+			total = PropsValues.INDEX_SEARCH_LIMIT;
+		}
+
 		BrowseHit[] browseHits = browseResult.getHits();
 
 		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-54494
Caused by https://issues.liferay.com/browse/LPS-44108 liferay@ae0b424

It doesn't make sense to use the number of total possible hits (numHits) when it's greater than our internal limit, since those results will be unreachable for end-users.

You can forward it to Tina.

Thanks,
Tibor

