### PR TITLE
[TECHNICAL-SUPPORT] LPS-59298 Listeners are not triggered after suspended thread resumes

### DIFF
--- a/modules/portal/portal-cluster/src/com/liferay/portal/cluster/internal/ClusterExecutorImpl.java
+++ b/modules/portal/portal-cluster/src/com/liferay/portal/cluster/internal/ClusterExecutorImpl.java
@@ -563,6 +563,11 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 		ClusterNodeStatus oldClusterNodeStatus = _clusterNodeStatuses.put(
 			clusterNodeStatus.getClusterNodeId(), clusterNodeStatus);
 
+		ClusterEvent clusterEvent = ClusterEvent.join(
+			clusterNodeStatus.getClusterNode());
+
+		fireClusterEvent(clusterEvent);
+
 		if (oldClusterNodeStatus != null) {
 			if (!oldClusterNodeStatus.equals(clusterNodeStatus)) {
 				if (_log.isInfoEnabled()) {
@@ -574,11 +579,6 @@ public class ClusterExecutorImpl implements ClusterExecutor {
 
 			return false;
 		}
-
-		ClusterEvent clusterEvent = ClusterEvent.join(
-			clusterNodeStatus.getClusterNode());
-
-		fireClusterEvent(clusterEvent);
 
 		return true;
 	}


### PR DESCRIPTION
**Problem:**
Multiple master node can appear in cluster if the process of master node hangs for a while.

**Analysis:**
*ClusterMasterExecutorImpl._master* says if the node is master or not. This field is maintained by *ClusterMasterExcutorImpl.ClusterMasterTokenClusterEventListener* through *ClusterExcutorImpl._memberJoined()*.
```
	private boolean _memberJoined(ClusterNodeStatus clusterNodeStatus) {
		ClusterNodeStatus oldClusterNodeStatus = _clusterNodeStatuses.put(
			clusterNodeStatus.getClusterNodeId(), clusterNodeStatus);

		if (oldClusterNodeStatus != null) {
			if (!oldClusterNodeStatus.equals(clusterNodeStatus)) {
				if (_log.isInfoEnabled()) {
					_log.info(
						"Updated cluster node " +
							clusterNodeStatus.getClusterNode());
				}
			}

			return false;
		}

		ClusterEvent clusterEvent = ClusterEvent.join(
			clusterNodeStatus.getClusterNode());

		fireClusterEvent(clusterEvent);

		return true;
	}
```
For a previously suspended process *ClusterExcutorImpl._memberJoined()* is called, but the listeners are not fired as *oldClusterNodeStatus != null* are evaluated to true. This means that the given cluster node is already joined, so we don't do anything.

**Solution:**
I think we have to fire the listeners even if the nodes are already joined to make sure that nodes are not out of sync.

Thank you for checking it!
Pisti