### PR TITLE
LPS-73786 SF

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -62,8 +62,6 @@ public class UpgradeSocial extends UpgradeProcess {
 
 	protected int getCounterIncrement() throws Exception {
 		try (Statement s = connection.createStatement()) {
-			String query = "select max(activitySetId) from SocialActivitySet";
-
 			String counterQuery =
 				"select currentId from counter where name = '" +
 					Counter.class.getName() + CharPool.APOSTROPHE;
@@ -75,6 +73,8 @@ public class UpgradeSocial extends UpgradeProcess {
 					counter = rs.getInt("currentId");
 				}
 			}
+
+			String query = "select max(activitySetId) from SocialActivitySet";
 
 			try (ResultSet rs = s.executeQuery(query)) {
 				if (rs.next()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -45,7 +45,7 @@ public class UpgradeSocial extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (getCounterIncrement() > 0) {
+		if (getSocialActivitySetsCount() > 0) {
 			return;
 		}
 
@@ -95,6 +95,20 @@ public class UpgradeSocial extends UpgradeProcess {
 					long minActivityId = rs.getLong(1);
 
 					return increment - minActivityId;
+				}
+
+				return 0;
+			}
+		}
+	}
+
+	protected int getSocialActivitySetsCount() throws Exception {
+		try (Statement s = connection.createStatement()) {
+			String query = "select count(activitySetId) from SocialActivitySet";
+
+			try (ResultSet rs = s.executeQuery(query)) {
+				if (rs.next()) {
+					return rs.getInt(1);
 				}
 
 				return 0;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 2.0.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 1.5.0


### PR DESCRIPTION
Hey @NorbertKocsis 

We cannot have major changes in portal-impl so I kept the method. Actually I think it makes sense to use that method to decide whether or not the upgrade should run.

Regarding the new method `getCounterIncrement` could we use PreparedStatement with `?` and include `Counter.class.getName()` as `ps.setString()`. Although the classname should be safe it's better to do it with prepared statement.

Could you please do that and resend?

Thanks!