### PR TITLE
LPS-73915 User Group updated attribute is not exported to LDAP on User association changes

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAP.java
@@ -83,9 +83,7 @@ public interface PortalLDAP {
 			String filter, Attribute attribute)
 		throws Exception;
 
-	public String getNameInNamespace(
-			long ldapServerId, long companyId, Binding binding)
-		throws Exception;
+	public String getNameInNamespace(Binding binding) throws Exception;
 
 	public Binding getUser(
 			long ldapServerId, long companyId, String screenName,

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAPUtil.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAPUtil.java
@@ -139,12 +139,8 @@ public class PortalLDAPUtil {
 			companyId, ldapContext, baseDN, filter, attribute);
 	}
 
-	public static String getNameInNamespace(
-			long ldapServerId, long companyId, Binding binding)
-		throws Exception {
-
-		return getInstance().getNameInNamespace(
-			ldapServerId, companyId, binding);
+	public static String getNameInNamespace(Binding binding) throws Exception {
+		return getInstance().getNameInNamespace(binding);
 	}
 
 	public static Binding getUser(

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -181,7 +181,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 				return null;
 			}
 
-			String baseDN = ldapServerConfiguration.baseDN();
+			String groupsDN = ldapServerConfiguration.groupsDN();
 
 			String groupFilter = ldapServerConfiguration.groupSearchFilter();
 
@@ -215,7 +215,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			SearchControls searchControls = new SearchControls(
 				SearchControls.SUBTREE_SCOPE, 1, 0, null, false, false);
 
-			enu = ldapContext.search(baseDN, sb.toString(), searchControls);
+			enu = ldapContext.search(groupsDN, sb.toString(), searchControls);
 
 			if (enu.hasMoreElements()) {
 				return enu.nextElement();
@@ -323,11 +323,11 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			_ldapServerConfigurationProvider.getConfiguration(
 				companyId, ldapServerId);
 
-		String baseDN = ldapServerConfiguration.baseDN();
+		String groupsDN = ldapServerConfiguration.groupsDN();
 		String groupSearchFilter = ldapServerConfiguration.groupSearchFilter();
 
 		return getGroups(
-			companyId, ldapContext, cookie, maxResults, baseDN,
+			companyId, ldapContext, cookie, maxResults, groupsDN,
 			groupSearchFilter, searchResults);
 	}
 
@@ -342,11 +342,11 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			_ldapServerConfigurationProvider.getConfiguration(
 				companyId, ldapServerId);
 
-		String baseDN = ldapServerConfiguration.baseDN();
+		String groupsDN = ldapServerConfiguration.groupsDN();
 		String groupSearchFilter = ldapServerConfiguration.groupSearchFilter();
 
 		return getGroups(
-			companyId, ldapContext, cookie, maxResults, baseDN,
+			companyId, ldapContext, cookie, maxResults, groupsDN,
 			groupSearchFilter, attributeIds, searchResults);
 	}
 

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -472,30 +472,8 @@ public class DefaultPortalLDAP implements PortalLDAP {
 	}
 
 	@Override
-	public String getNameInNamespace(
-			long ldapServerId, long companyId, Binding binding)
-		throws Exception {
-
-		LDAPServerConfiguration ldapServerConfiguration =
-			_ldapServerConfigurationProvider.getConfiguration(
-				companyId, ldapServerId);
-
-		String baseDN = ldapServerConfiguration.baseDN();
-
-		String name = binding.getName();
-
-		if (name.startsWith(StringPool.QUOTE) &&
-			name.endsWith(StringPool.QUOTE)) {
-
-			name = name.substring(1, name.length() - 1);
-		}
-
-		if (Validator.isNull(baseDN)) {
-			return name;
-		}
-		else {
-			return name.concat(StringPool.COMMA).concat(baseDN);
-		}
+	public String getNameInNamespace(Binding binding) throws Exception {
+		return binding.getNameInNamespace();
 	}
 
 	@Override

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -312,8 +312,7 @@ public class LDAPAuth implements Authenticator {
 
 			SearchResult result = enu.nextElement();
 
-			String fullUserDN = _portalLDAP.getNameInNamespace(
-				ldapServerId, companyId, result);
+			String fullUserDN = _portalLDAP.getNameInNamespace(result);
 
 			Attributes attributes = _portalLDAP.getUserAttributes(
 				ldapServerId, companyId, ldapContext, fullUserDN);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -173,7 +173,8 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			UserOperation userOperation)
 		throws Exception {
 
-		Modifications modifications = Modifications.getInstance();
+		Modifications modifications = getModifications(
+			userGroup, groupMappings, new HashMap<String, String>());
 
 		String groupDN = getGroupDNName(ldapServerId, userGroup, groupMappings);
 		String userDN = getUserDNName(ldapServerId, user, userMappings);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -92,8 +92,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			ldapServerId, userGroup.getCompanyId(), userGroup.getName());
 
 		if (groupBinding != null) {
-			return _portalLDAP.getNameInNamespace(
-				ldapServerId, userGroup.getCompanyId(), groupBinding);
+			return _portalLDAP.getNameInNamespace(groupBinding);
 		}
 
 		StringBundler sb = new StringBundler(5);
@@ -342,8 +341,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			user.getEmailAddress());
 
 		if (userBinding != null) {
-			return _portalLDAP.getNameInNamespace(
-				ldapServerId, user.getCompanyId(), userBinding);
+			return _portalLDAP.getNameInNamespace(userBinding);
 		}
 
 		StringBundler sb = new StringBundler(5);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
@@ -127,9 +127,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(_portalLDAP.getNameInNamespace(binding));
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPContactModifications(
@@ -221,9 +219,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 		try {
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(_portalLDAP.getNameInNamespace(binding));
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPGroupModifications(
@@ -242,8 +238,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 					sve);
 			}
 
-			String fullGroupDN = _portalLDAP.getNameInNamespace(
-				ldapServerId, companyId, binding);
+			String fullGroupDN = _portalLDAP.getNameInNamespace(binding);
 
 			Attributes attributes = _portalLDAP.getGroupAttributes(
 				ldapServerId, companyId, ldapContext, fullGroupDN, true);
@@ -312,8 +307,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 			else {
 				Attributes attributes = _portalLDAP.getUserAttributes(
 					ldapServerId, companyId, ldapContext,
-					_portalLDAP.getNameInNamespace(
-						ldapServerId, companyId, binding));
+					_portalLDAP.getNameInNamespace(binding));
 
 				String modifyTimestamp = LDAPUtil.getAttributeString(
 					attributes, "modifyTimestamp");
@@ -335,9 +329,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(_portalLDAP.getNameInNamespace(binding));
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPUserModifications(

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -224,8 +224,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 				Attributes attributes = _portalLDAP.getUserAttributes(
 					ldapServerId, companyId, ldapContext,
-					_portalLDAP.getNameInNamespace(
-						ldapServerId, companyId, binding));
+					_portalLDAP.getNameInNamespace(binding));
 
 				return importUser(
 					ldapServerId, companyId, ldapContext, attributes, null);
@@ -327,8 +326,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 		LdapContext ldapContext = _portalLDAP.getContext(
 			ldapServerId, companyId);
 
-		String fullUserDN = _portalLDAP.getNameInNamespace(
-			ldapServerId, companyId, result);
+		String fullUserDN = _portalLDAP.getNameInNamespace(result);
 
 		Attributes attributes = _portalLDAP.getUserAttributes(
 			ldapServerId, companyId, ldapContext, fullUserDN);
@@ -760,10 +758,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 						ldapImportContext.getLdapServerId(),
 						ldapImportContext.getCompanyId(),
 						ldapImportContext.getLdapContext(),
-						_portalLDAP.getNameInNamespace(
-							ldapImportContext.getLdapServerId(),
-							ldapImportContext.getCompanyId(), searchResult),
-						true);
+						_portalLDAP.getNameInNamespace(searchResult), true);
 
 					UserGroup userGroup = importUserGroup(
 						ldapImportContext.getCompanyId(), groupAttributes,
@@ -817,8 +812,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			for (SearchResult searchResult : searchResults) {
 				try {
 					String fullUserDN = _portalLDAP.getNameInNamespace(
-						ldapImportContext.getLdapServerId(),
-						ldapImportContext.getCompanyId(), searchResult);
+						searchResult);
 
 					if (ldapImportContext.containsImportedUser(fullUserDN)) {
 						continue;
@@ -973,9 +967,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				ldapImportContext.getCompanyId(), user.getScreenName(),
 				user.getEmailAddress());
 
-			String fullUserDN = _portalLDAP.getNameInNamespace(
-				ldapImportContext.getLdapServerId(),
-				ldapImportContext.getCompanyId(), binding);
+			String fullUserDN = _portalLDAP.getNameInNamespace(binding);
 
 			sb.append(escapeValue(fullUserDN));
 
@@ -1001,8 +993,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 				for (SearchResult searchResult : searchResults) {
 					String fullGroupDN = _portalLDAP.getNameInNamespace(
-						ldapImportContext.getLdapServerId(),
-						ldapImportContext.getCompanyId(), searchResult);
+						searchResult);
 
 					newUserGroupIds = importGroup(
 						ldapImportContext, fullGroupDN, user, newUserGroupIds);


### PR DESCRIPTION
[LPS-73915](https://issues.liferay.com/browse/LPS-73915)

Hi Norbi,

Please review my changes.

**Issue:** On User - UserGroup association changes the updated UserGroup attributes doesn't get exported into LDAP.

**Solution:** There are two main changes.
- use groupsDN instead of baseDN where applies to ensure we find the group in LDAP at all
- add updated UserGroup attributes to the modifications

Thanks in advance,
Pisti