### PR TITLE
LPS-73915 User Group updated attribute is not exported to LDAP on User association changes

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAP.java
@@ -83,6 +83,10 @@ public interface PortalLDAP {
 			String filter, Attribute attribute)
 		throws Exception;
 
+	/**
+	 * @deprecated As of 2.2.0
+	 */
+	@Deprecated
 	public String getNameInNamespace(
 			long ldapServerId, long companyId, Binding binding)
 		throws Exception;

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAPUtil.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/PortalLDAPUtil.java
@@ -139,6 +139,10 @@ public class PortalLDAPUtil {
 			companyId, ldapContext, baseDN, filter, attribute);
 	}
 
+	/**
+	 * @deprecated As of 2.2.0
+	 */
+	@Deprecated
 	public static String getNameInNamespace(
 			long ldapServerId, long companyId, Binding binding)
 		throws Exception {

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -181,7 +181,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 				return null;
 			}
 
-			String baseDN = ldapServerConfiguration.baseDN();
+			String groupsDN = ldapServerConfiguration.groupsDN();
 
 			String groupFilter = ldapServerConfiguration.groupSearchFilter();
 
@@ -215,7 +215,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			SearchControls searchControls = new SearchControls(
 				SearchControls.SUBTREE_SCOPE, 1, 0, null, false, false);
 
-			enu = ldapContext.search(baseDN, sb.toString(), searchControls);
+			enu = ldapContext.search(groupsDN, sb.toString(), searchControls);
 
 			if (enu.hasMoreElements()) {
 				return enu.nextElement();
@@ -323,11 +323,11 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			_ldapServerConfigurationProvider.getConfiguration(
 				companyId, ldapServerId);
 
-		String baseDN = ldapServerConfiguration.baseDN();
+		String groupsDN = ldapServerConfiguration.groupsDN();
 		String groupSearchFilter = ldapServerConfiguration.groupSearchFilter();
 
 		return getGroups(
-			companyId, ldapContext, cookie, maxResults, baseDN,
+			companyId, ldapContext, cookie, maxResults, groupsDN,
 			groupSearchFilter, searchResults);
 	}
 
@@ -342,11 +342,11 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			_ldapServerConfigurationProvider.getConfiguration(
 				companyId, ldapServerId);
 
-		String baseDN = ldapServerConfiguration.baseDN();
+		String groupsDN = ldapServerConfiguration.groupsDN();
 		String groupSearchFilter = ldapServerConfiguration.groupSearchFilter();
 
 		return getGroups(
-			companyId, ldapContext, cookie, maxResults, baseDN,
+			companyId, ldapContext, cookie, maxResults, groupsDN,
 			groupSearchFilter, attributeIds, searchResults);
 	}
 

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -471,6 +471,10 @@ public class DefaultPortalLDAP implements PortalLDAP {
 		return attribute;
 	}
 
+	/**
+	 * @deprecated As of 2.2.0
+	 */
+	@Deprecated
 	@Override
 	public String getNameInNamespace(
 			long ldapServerId, long companyId, Binding binding)

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -312,8 +312,7 @@ public class LDAPAuth implements Authenticator {
 
 			SearchResult result = enu.nextElement();
 
-			String fullUserDN = _portalLDAP.getNameInNamespace(
-				ldapServerId, companyId, result);
+			String fullUserDN = result.getNameInNamespace();
 
 			Attributes attributes = _portalLDAP.getUserAttributes(
 				ldapServerId, companyId, ldapContext, fullUserDN);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -173,7 +173,8 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			UserOperation userOperation)
 		throws Exception {
 
-		Modifications modifications = Modifications.getInstance();
+		Modifications modifications = getModifications(
+			userGroup, groupMappings, new HashMap<String, String>());
 
 		String groupDN = getGroupDNName(ldapServerId, userGroup, groupMappings);
 		String userDN = getUserDNName(ldapServerId, user, userMappings);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -92,8 +92,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			ldapServerId, userGroup.getCompanyId(), userGroup.getName());
 
 		if (groupBinding != null) {
-			return _portalLDAP.getNameInNamespace(
-				ldapServerId, userGroup.getCompanyId(), groupBinding);
+			return groupBinding.getNameInNamespace();
 		}
 
 		StringBundler sb = new StringBundler(5);
@@ -342,8 +341,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 			user.getEmailAddress());
 
 		if (userBinding != null) {
-			return _portalLDAP.getNameInNamespace(
-				ldapServerId, user.getCompanyId(), userBinding);
+			return userBinding.getNameInNamespace();
 		}
 
 		StringBundler sb = new StringBundler(5);

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
@@ -127,9 +127,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(binding.getNameInNamespace());
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPContactModifications(
@@ -221,9 +219,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 		try {
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(binding.getNameInNamespace());
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPGroupModifications(
@@ -242,8 +238,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 					sve);
 			}
 
-			String fullGroupDN = _portalLDAP.getNameInNamespace(
-				ldapServerId, companyId, binding);
+			String fullGroupDN = binding.getNameInNamespace();
 
 			Attributes attributes = _portalLDAP.getGroupAttributes(
 				ldapServerId, companyId, ldapContext, fullGroupDN, true);
@@ -312,8 +307,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 			else {
 				Attributes attributes = _portalLDAP.getUserAttributes(
 					ldapServerId, companyId, ldapContext,
-					_portalLDAP.getNameInNamespace(
-						ldapServerId, companyId, binding));
+					binding.getNameInNamespace());
 
 				String modifyTimestamp = LDAPUtil.getAttributeString(
 					attributes, "modifyTimestamp");
@@ -335,9 +329,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 
 			Name name = new CompositeName();
 
-			name.add(
-				_portalLDAP.getNameInNamespace(
-					ldapServerId, companyId, binding));
+			name.add(binding.getNameInNamespace());
 
 			Modifications modifications =
 				_portalToLDAPConverter.getLDAPUserModifications(

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -224,8 +224,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 				Attributes attributes = _portalLDAP.getUserAttributes(
 					ldapServerId, companyId, ldapContext,
-					_portalLDAP.getNameInNamespace(
-						ldapServerId, companyId, binding));
+					binding.getNameInNamespace());
 
 				return importUser(
 					ldapServerId, companyId, ldapContext, attributes, null);
@@ -327,8 +326,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 		LdapContext ldapContext = _portalLDAP.getContext(
 			ldapServerId, companyId);
 
-		String fullUserDN = _portalLDAP.getNameInNamespace(
-			ldapServerId, companyId, result);
+		String fullUserDN = result.getNameInNamespace();
 
 		Attributes attributes = _portalLDAP.getUserAttributes(
 			ldapServerId, companyId, ldapContext, fullUserDN);
@@ -760,10 +758,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 						ldapImportContext.getLdapServerId(),
 						ldapImportContext.getCompanyId(),
 						ldapImportContext.getLdapContext(),
-						_portalLDAP.getNameInNamespace(
-							ldapImportContext.getLdapServerId(),
-							ldapImportContext.getCompanyId(), searchResult),
-						true);
+						searchResult.getNameInNamespace(), true);
 
 					UserGroup userGroup = importUserGroup(
 						ldapImportContext.getCompanyId(), groupAttributes,
@@ -816,9 +811,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			for (SearchResult searchResult : searchResults) {
 				try {
-					String fullUserDN = _portalLDAP.getNameInNamespace(
-						ldapImportContext.getLdapServerId(),
-						ldapImportContext.getCompanyId(), searchResult);
+					String fullUserDN = searchResult.getNameInNamespace();
 
 					if (ldapImportContext.containsImportedUser(fullUserDN)) {
 						continue;
@@ -973,9 +966,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				ldapImportContext.getCompanyId(), user.getScreenName(),
 				user.getEmailAddress());
 
-			String fullUserDN = _portalLDAP.getNameInNamespace(
-				ldapImportContext.getLdapServerId(),
-				ldapImportContext.getCompanyId(), binding);
+			String fullUserDN = binding.getNameInNamespace();
 
 			sb.append(escapeValue(fullUserDN));
 
@@ -1000,9 +991,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					searchResults);
 
 				for (SearchResult searchResult : searchResults) {
-					String fullGroupDN = _portalLDAP.getNameInNamespace(
-						ldapImportContext.getLdapServerId(),
-						ldapImportContext.getCompanyId(), searchResult);
+					String fullGroupDN = searchResult.getNameInNamespace();
 
 					newUserGroupIds = importGroup(
 						ldapImportContext, fullGroupDN, user, newUserGroupIds);


### PR DESCRIPTION
[LPS-73915](https://issues.liferay.com/browse/LPS-73915)

Hi Norbi,

I've fixed the semver problem in my previous PR (https://github.com/NorbertKocsis/liferay-portal/pull/46). Please review my changes.

**Issue:** On User - UserGroup association changes the updated UserGroup attributes doesn't get exported into LDAP.

**Solution:** There are two main changes.
- use groupsDN instead of baseDN where applies to ensure we find the group in LDAP at all
- add updated UserGroup attributes to the modifications

Thanks in advance,
Pisti