### PR TITLE
[TS] LPS-77929 Password encryption scheme (algorithm name) is exported incorrectly to LDAP

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/authenticator/configuration/LDAPAuthConfiguration.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/authenticator/configuration/LDAPAuthConfiguration.java
@@ -58,9 +58,13 @@ public interface LDAPAuthConfiguration extends CompanyScopedConfiguration {
 	@Meta.AD(
 		deflt = "NONE", description = "password-encryption-algorithm-help",
 		name = "password-encryption-algorithm",
-		optionValues = {
+		optionLabels = {
 			"BCRYPT", "MD2", "MD5", "NONE", "SHA", "SHA-256", "SHA-384", "SSHA",
 			"UFC-CRYPT"
+		},
+		optionValues = {
+			"BCRYPT", "MD2", "MD5", "NONE", "SHA", "SHA-256", "SHA-384", "SSHA",
+			"CRYPT"
 		},
 		required = false
 	)

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/DefaultPortalToLDAPConverter.java
@@ -16,6 +16,7 @@ package com.liferay.portal.security.ldap.internal.exportimport;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.expando.kernel.util.ExpandoConverterUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.exportimport.UserOperation;
 import com.liferay.portal.security.ldap.GroupConverterKeys;
@@ -440,7 +442,7 @@ public class DefaultPortalToLDAPConverter implements PortalToLDAPConverter {
 				!hasLegacyPasswordEncryptionAlgorithm()) {
 
 				sb.append(StringPool.OPEN_CURLY_BRACE);
-				sb.append(algorithm);
+				sb.append(StringUtil.removeChar(algorithm, CharPool.DASH));
 				sb.append(StringPool.CLOSE_CURLY_BRACE);
 			}
 

--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/resources/com/liferay/portal/security/ldap/authenticator/configuration/packageinfo
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/resources/com/liferay/portal/security/ldap/authenticator/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.0.3

--- a/modules/apps/foundation/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/constants/LDAPSettingsConstants.java
+++ b/modules/apps/foundation/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/constants/LDAPSettingsConstants.java
@@ -44,6 +44,6 @@ public class LDAPSettingsConstants {
 
 	public static final String SSHA = "SSHA";
 
-	public static final String UFC_CRYPT = "UFC-CRYPT";
+	public static final String UFC_CRYPT = "CRYPT";
 
 }

--- a/portal-impl/src/com/liferay/portal/security/pwd/CryptPasswordEncryptor.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/CryptPasswordEncryptor.java
@@ -54,10 +54,7 @@ public class CryptPasswordEncryptor
 
 	@Override
 	public String[] getSupportedAlgorithmTypes() {
-		return new String[] {
-			PasswordEncryptorUtil.TYPE_UFC_CRYPT,
-			PasswordEncryptorUtil.TYPE_UFC_CRYPT
-		};
+		return new String[] {PasswordEncryptorUtil.TYPE_UFC_CRYPT};
 	}
 
 	protected byte[] getSalt(String encryptedPassword)

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -52,7 +52,7 @@ public class PasswordEncryptorUtil {
 
 	public static final String TYPE_SSHA = "SSHA";
 
-	public static final String TYPE_UFC_CRYPT = "UFC-CRYPT";
+	public static final String TYPE_UFC_CRYPT = "CRYPT";
 
 	public static String encrypt(String plainTextPassword)
 		throws PwdEncryptorException {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.0.1


### PR DESCRIPTION
[LPS-77929](https://issues.liferay.com/browse/LPS-77929)

Hi Norbi,

Please review my changes.

In short, there are conventions (not specified by standards) how password encryption schemes are stored by LDAP servers. Seemingly we don't follow those conventions entirely, which leads to authentication problems with certain _encryption type - LDAP server_ combinations. (More details on the ticket.)

Should you have any questions, you know where to find me. :)

Thank you, 
Pisti