### PR TITLE
LPS-81573 Add test for .config format

### DIFF
--- a/modules/apps/portal-configuration/portal-configuration-extender/build.gradle
+++ b/modules/apps/portal-configuration/portal-configuration-extender/build.gradle
@@ -16,6 +16,7 @@ copyTestLibs {
 
 dependencies {
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "3.1.0"
+	compileOnly group: "com.liferay", name: "org.apache.felix.fileinstall", version: "3.5.4.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.5.0"

--- a/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileConfigurationDescriptionFactoryImpl.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileConfigurationDescriptionFactoryImpl.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.extender.internal.support.config.file;
+
+import com.liferay.portal.configuration.extender.internal.ConfigurationDescription;
+import com.liferay.portal.configuration.extender.internal.ConfigurationDescriptionFactory;
+import com.liferay.portal.configuration.extender.internal.FactoryConfigurationDescription;
+import com.liferay.portal.configuration.extender.internal.NamedConfigurationContent;
+import com.liferay.portal.configuration.extender.internal.SingleConfigurationDescription;
+import com.liferay.portal.kernel.util.Supplier;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.util.Dictionary;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+@Component(immediate = true)
+public class ConfigFileConfigurationDescriptionFactoryImpl
+	implements ConfigurationDescriptionFactory {
+
+	@Override
+	public ConfigurationDescription create(
+		NamedConfigurationContent namedConfigurationContent) {
+
+		if (!(namedConfigurationContent instanceof
+				ConfigFileNamedConfigurationContent)) {
+
+			return null;
+		}
+
+		String factoryPid = null;
+		String pid = null;
+
+		String name = namedConfigurationContent.getName();
+
+		int index = name.lastIndexOf('-');
+
+		if (index > 0) {
+			factoryPid = name.substring(0, index);
+			pid = name.substring(index + 1);
+
+			return new FactoryConfigurationDescription(
+				factoryPid, pid,
+				new PropertiesSupplier(
+					namedConfigurationContent.getInputStream()));
+		}
+		else {
+			pid = name;
+
+			return new SingleConfigurationDescription(
+				pid,
+				new PropertiesSupplier(
+					namedConfigurationContent.getInputStream()));
+		}
+	}
+
+	private class PropertiesSupplier
+		implements Supplier<Dictionary<String, Object>> {
+
+		public PropertiesSupplier(InputStream inputStream) {
+			_inputStream = inputStream;
+		}
+
+		@Override
+		public Dictionary<String, Object> get() {
+			try {
+				return _loadProperties();
+			}
+			catch (IOException ioe) {
+				throw new RuntimeException(ioe);
+			}
+		}
+
+		private Dictionary<String, Object> _loadProperties()
+			throws IOException {
+
+			Dictionary<?, ?> properties = ConfigurationHandler.read(
+				_inputStream);
+
+			return (Dictionary<String, Object>)properties;
+		}
+
+		private final InputStream _inputStream;
+
+	}
+
+}

--- a/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileNamedConfigurationContent.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileNamedConfigurationContent.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.extender.internal.support.config.file;
+
+import com.liferay.portal.configuration.extender.internal.NamedConfigurationContent;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.URL;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public final class ConfigFileNamedConfigurationContent
+	implements NamedConfigurationContent {
+
+	public ConfigFileNamedConfigurationContent(
+		String name, InputStream inputStream) {
+
+		_name = name;
+		_inputStream = inputStream;
+	}
+
+	public ConfigFileNamedConfigurationContent(URL url) {
+		String name = url.getFile();
+
+		if (name.startsWith("/")) {
+			name = name.substring(1);
+		}
+
+		int lastIndexOfSlash = name.lastIndexOf('/');
+
+		if (lastIndexOfSlash > 0) {
+			name = name.substring(lastIndexOfSlash + 1);
+		}
+
+		if (!name.endsWith(".config")) {
+			throw new IllegalArgumentException(
+				"File name does not end with .config");
+		}
+
+		_name = name.substring(0, name.length() - 7);
+
+		try {
+			_inputStream = url.openStream();
+		}
+		catch (IOException ioe) {
+			throw new RuntimeException(ioe);
+		}
+	}
+
+	@Override
+	public InputStream getInputStream() {
+		return _inputStream;
+	}
+
+	@Override
+	public String getName() {
+		return _name;
+	}
+
+	private final InputStream _inputStream;
+	private final String _name;
+
+}

--- a/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileNamedConfigurationPathContentFactory.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender/src/main/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileNamedConfigurationPathContentFactory.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.extender.internal.support.config.file;
+
+import com.liferay.portal.configuration.extender.internal.BundleStorage;
+import com.liferay.portal.configuration.extender.internal.NamedConfigurationContent;
+import com.liferay.portal.configuration.extender.internal.NamedConfigurationContentFactory;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MappingEnumeration;
+import com.liferay.portal.kernel.util.MappingEnumeration.Mapper;
+
+import java.net.URL;
+
+import java.util.Dictionary;
+import java.util.Enumeration;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+@Component(immediate = true)
+public class ConfigFileNamedConfigurationPathContentFactory
+	implements NamedConfigurationContentFactory {
+
+	@Override
+	public List<NamedConfigurationContent> create(BundleStorage bundleStorage) {
+		Dictionary<String, String> headers = bundleStorage.getHeaders();
+
+		String configurationPath = headers.get("Liferay-Configuration-Path");
+
+		if (configurationPath == null) {
+			return null;
+		}
+
+		final Enumeration<URL> entries = bundleStorage.findEntries(
+			configurationPath, "*.config", true);
+
+		return ListUtil.fromEnumeration(
+			new MappingEnumeration<>(
+				entries,
+				new Mapper<URL, NamedConfigurationContent>() {
+
+					@Override
+					public NamedConfigurationContent map(URL url) {
+						return new ConfigFileNamedConfigurationContent(url);
+					}
+
+				}));
+	}
+
+}

--- a/modules/apps/portal-configuration/portal-configuration-extender/src/test/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileConfigurationDescriptionFactoryImplTest.java
+++ b/modules/apps/portal-configuration/portal-configuration-extender/src/test/java/com/liferay/portal/configuration/extender/internal/support/config/file/ConfigFileConfigurationDescriptionFactoryImplTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.configuration.extender.internal.support.config.file;
+
+import com.liferay.portal.configuration.extender.internal.ConfigurationDescription;
+import com.liferay.portal.configuration.extender.internal.ConfigurationDescriptionFactory;
+import com.liferay.portal.configuration.extender.internal.ConfigurationDescriptionFactoryImpl;
+import com.liferay.portal.configuration.extender.internal.FactoryConfigurationDescription;
+import com.liferay.portal.configuration.extender.internal.NamedConfigurationContent;
+import com.liferay.portal.configuration.extender.internal.SingleConfigurationDescription;
+import com.liferay.portal.kernel.util.Supplier;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import java.nio.charset.Charset;
+
+import java.util.Dictionary;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+public class ConfigFileConfigurationDescriptionFactoryImplTest {
+
+	@Test
+	public void testCreateFactoryConfiguration() {
+		ConfigurationDescriptionFactory configurationDescriptionFactory =
+			new ConfigFileConfigurationDescriptionFactoryImpl();
+
+		String configurationContent =
+			"key=\"value\"\nanotherKey=\"anotherValue\"";
+
+		ConfigurationDescription configurationDescription =
+			configurationDescriptionFactory.create(
+				new ConfigFileNamedConfigurationContent(
+					"factory.pid-config.pid",
+					new ByteArrayInputStream(
+						configurationContent.getBytes(
+							Charset.forName("UTF-8")))));
+
+		Assert.assertTrue(
+			configurationDescription instanceof
+				FactoryConfigurationDescription);
+
+		FactoryConfigurationDescription factoryConfigurationDescription =
+			(FactoryConfigurationDescription)configurationDescription;
+
+		Assert.assertEquals(
+			"factory.pid", factoryConfigurationDescription.getFactoryPid());
+		Assert.assertEquals(
+			"config.pid", factoryConfigurationDescription.getPid());
+
+		Supplier<Dictionary<String, Object>> propertiesSupplier =
+			factoryConfigurationDescription.getPropertiesSupplier();
+
+		Dictionary<String, Object> properties = propertiesSupplier.get();
+
+		Assert.assertEquals("value", properties.get("key"));
+		Assert.assertEquals("anotherValue", properties.get("anotherKey"));
+	}
+
+	@Test
+	public void testCreateReturnsNullWhenNotPropertiesFileNamedConfigurationContent() {
+		ConfigurationDescriptionFactory configurationDescriptionFactory =
+			new ConfigurationDescriptionFactoryImpl();
+
+		ConfigurationDescription configurationDescription =
+			configurationDescriptionFactory.create(
+				new NamedConfigurationContent() {
+
+					@Override
+					public InputStream getInputStream() {
+						return new ByteArrayInputStream(new byte[0]);
+					}
+
+					@Override
+					public String getName() {
+						return "aName";
+					}
+
+				});
+
+		Assert.assertNull(configurationDescription);
+	}
+
+	@Test
+	public void testCreateSingleConfiguration() {
+		ConfigurationDescriptionFactory configurationDescriptionFactory =
+			new ConfigFileConfigurationDescriptionFactoryImpl();
+
+		String configurationContent =
+			"key=\"value\"\nanotherKey=\"anotherValue\"";
+
+		ConfigurationDescription configurationDescription =
+			configurationDescriptionFactory.create(
+				new ConfigFileNamedConfigurationContent(
+					"config.pid",
+					new ByteArrayInputStream(
+						configurationContent.getBytes(
+							Charset.forName("UTF-8")))));
+
+		Assert.assertTrue(
+			configurationDescription instanceof SingleConfigurationDescription);
+
+		SingleConfigurationDescription singleConfigurationDescription =
+			(SingleConfigurationDescription)configurationDescription;
+
+		Assert.assertEquals(
+			"config.pid", singleConfigurationDescription.getPid());
+
+		Supplier<Dictionary<String, Object>> propertiesSupplier =
+			singleConfigurationDescription.getPropertiesSupplier();
+
+		Dictionary<String, Object> properties = propertiesSupplier.get();
+
+		Assert.assertEquals("value", properties.get("key"));
+		Assert.assertEquals("anotherValue", properties.get("anotherKey"));
+	}
+
+}


### PR DESCRIPTION
This pull add support for `.config` fileinstall format. 
To use it the files should end with `.config` suffix. 

Let me know if this addresses your problem for https://issues.liferay.com/browse/LPS-81573