### PR TITLE
LPS-82695

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -73,20 +73,38 @@ public class UpgradeSocial extends UpgradeProcess {
 
 		updateSocialActivities(delta);
 
-		increment(Counter.class.getName(), getCounterIncrement());
+		long counterIncrement = _getCounterIncrement();
+
+		while (counterIncrement > Integer.MAX_VALUE) {
+			increment(Counter.class.getName(), Integer.MAX_VALUE);
+
+			counterIncrement -= Integer.MAX_VALUE;
+		}
+
+		if (counterIncrement > 0) {
+			increment(Counter.class.getName(), (int)counterIncrement);
+		}
 	}
 
+	/**
+	 * @deprecated As of Judson (7.1.x), with no direct replacement.
+	 */
+	@Deprecated
 	protected int getCounterIncrement() throws Exception {
+		return (int)_getCounterIncrement();
+	}
+
+	private long _getCounterIncrement() throws Exception {
 		try (PreparedStatement ps1 = connection.prepareStatement(
 				"select currentId from Counter where name = ?")) {
 
 			ps1.setString(1, Counter.class.getName());
 
-			int counter = 0;
+			long counter = 0;
 
 			try (ResultSet rs = ps1.executeQuery()) {
 				if (rs.next()) {
-					counter = rs.getInt("currentId");
+					counter = rs.getLong("currentId");
 				}
 			}
 
@@ -95,7 +113,7 @@ public class UpgradeSocial extends UpgradeProcess {
 
 			try (ResultSet rs = ps2.executeQuery()) {
 				if (rs.next()) {
-					return rs.getInt(1) - counter;
+					return rs.getLong(1) - counter;
 				}
 
 				return 0;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -77,6 +77,26 @@ public class UpgradeSocial extends UpgradeProcess {
 		incrementCounter();
 	}
 
+	protected void incrementCounter() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+			"select max(activitySetId) from SocialActivitySet");
+			 ResultSet rs = ps.executeQuery();) {
+
+			if (rs.next()) {
+				Counter counter = CounterLocalServiceUtil.getCounter(
+					Counter.class.getName());
+
+				long lastSocialActivitySetId = rs.getLong(1);
+
+				if (counter.getCurrentId() < lastSocialActivitySetId) {
+					counter.setCurrentId(rs.getLong(1));
+
+					CounterLocalServiceUtil.updateCounter(counter);
+				}
+			}
+		}
+	}
+
 	protected long getDelta(long increment) throws Exception {
 		try (Statement s = connection.createStatement()) {
 			try (ResultSet rs = s.executeQuery(
@@ -103,26 +123,6 @@ public class UpgradeSocial extends UpgradeProcess {
 				}
 
 				return 0;
-			}
-		}
-	}
-
-	protected void incrementCounter() throws Exception {
-		try (PreparedStatement ps = connection.prepareStatement(
-			"select max(activitySetId) from SocialActivitySet");
-			 ResultSet rs = ps.executeQuery();) {
-
-			if (rs.next()) {
-				Counter counter = CounterLocalServiceUtil.getCounter(
-					Counter.class.getName());
-
-				long lastSocialActivitySetId = rs.getLong(1);
-
-				if (counter.getCurrentId() < lastSocialActivitySetId) {
-					counter.setCurrentId(rs.getLong(1));
-
-					CounterLocalServiceUtil.updateCounter(counter);
-				}
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -77,26 +77,6 @@ public class UpgradeSocial extends UpgradeProcess {
 		incrementCounter();
 	}
 
-	protected void incrementCounter() throws Exception {
-		try (PreparedStatement ps = connection.prepareStatement(
-			"select max(activitySetId) from SocialActivitySet");
-			 ResultSet rs = ps.executeQuery();) {
-
-			if (rs.next()) {
-				Counter counter = CounterLocalServiceUtil.getCounter(
-					Counter.class.getName());
-
-				long lastSocialActivitySetId = rs.getLong(1);
-
-				if (counter.getCurrentId() < lastSocialActivitySetId) {
-					counter.setCurrentId(rs.getLong(1));
-
-					CounterLocalServiceUtil.updateCounter(counter);
-				}
-			}
-		}
-	}
-
 	protected long getDelta(long increment) throws Exception {
 		try (Statement s = connection.createStatement()) {
 			try (ResultSet rs = s.executeQuery(
@@ -123,6 +103,26 @@ public class UpgradeSocial extends UpgradeProcess {
 				}
 
 				return 0;
+			}
+		}
+	}
+
+	protected void incrementCounter() throws Exception {
+		try (PreparedStatement ps = connection.prepareStatement(
+			"select max(activitySetId) from SocialActivitySet");
+			 ResultSet rs = ps.executeQuery();) {
+
+			if (rs.next()) {
+				Counter counter = CounterLocalServiceUtil.getCounter(
+					Counter.class.getName());
+
+				long lastSocialActivitySetId = rs.getLong(1);
+
+				if (counter.getCurrentId() < lastSocialActivitySetId) {
+					counter.setCurrentId(rs.getLong(1));
+
+					CounterLocalServiceUtil.updateCounter(counter);
+				}
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -87,38 +87,11 @@ public class UpgradeSocial extends UpgradeProcess {
 	}
 
 	/**
-	 * @deprecated As of Judson (7.1.x), with no direct replacement.
+	 * @deprecated As of Judson (7.1.x), with no direct replacement
 	 */
 	@Deprecated
 	protected int getCounterIncrement() throws Exception {
 		return (int)_getCounterIncrement();
-	}
-
-	private long _getCounterIncrement() throws Exception {
-		try (PreparedStatement ps1 = connection.prepareStatement(
-				"select currentId from Counter where name = ?")) {
-
-			ps1.setString(1, Counter.class.getName());
-
-			long counter = 0;
-
-			try (ResultSet rs = ps1.executeQuery()) {
-				if (rs.next()) {
-					counter = rs.getLong("currentId");
-				}
-			}
-
-			PreparedStatement ps2 = connection.prepareStatement(
-				"select max(activitySetId) from SocialActivitySet");
-
-			try (ResultSet rs = ps2.executeQuery()) {
-				if (rs.next()) {
-					return rs.getLong(1) - counter;
-				}
-
-				return 0;
-			}
-		}
 	}
 
 	protected long getDelta(long increment) throws Exception {
@@ -158,6 +131,33 @@ public class UpgradeSocial extends UpgradeProcess {
 			ps.setLong(1, delta);
 
 			ps.execute();
+		}
+	}
+
+	private long _getCounterIncrement() throws Exception {
+		try (PreparedStatement ps1 = connection.prepareStatement(
+				"select currentId from Counter where name = ?")) {
+
+			ps1.setString(1, Counter.class.getName());
+
+			long counter = 0;
+
+			try (ResultSet rs = ps1.executeQuery()) {
+				if (rs.next()) {
+					counter = rs.getLong("currentId");
+				}
+			}
+
+			PreparedStatement ps2 = connection.prepareStatement(
+				"select max(activitySetId) from SocialActivitySet");
+
+			try (ResultSet rs = ps2.executeQuery()) {
+				if (rs.next()) {
+					return rs.getLong(1) - counter;
+				}
+
+				return 0;
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeSocial.java
@@ -153,7 +153,7 @@ public class UpgradeSocial extends UpgradeProcess {
 
 			try (ResultSet rs = ps2.executeQuery()) {
 				if (rs.next()) {
-					return rs.getLong(1) - counter;
+					return Math.max(0, rs.getLong(1) - counter);
 				}
 
 				return 0;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.13.0
+version 2.0.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 1.13.0


### PR DESCRIPTION
Hey @NorbertKocsis,

Services cannot be used anymore in upgrades (there's a SF rule that
checks for that), so we need an alternative approach.

To avoid modifying the DB interface so that it accepts longs, here I
make sure the counter increment doesn't overflow by doing it multiple
times.

Could you help me testing this to verify it works ok?

Thanks!